### PR TITLE
1-cdf changed to survival function

### DIFF
--- a/lmm/lmm.py
+++ b/lmm/lmm.py
@@ -433,7 +433,7 @@ def calculate(t):
                 'tau': tau,
                 'lambda': lambda_restricted,
                 'F_wald': F_wald,
-                'p_wald': 1-stats.f.cdf(x=F_wald, dfn=1, dfd=n-c-1),
+                'p_wald': stats.f.sf(x=F_wald, dfn=1, dfd=n-c-1),
             })
         except np.linalg.LinAlgError as e:
             print(e)
@@ -470,7 +470,7 @@ def calculate_de(t):
                 'tau': tau,
                 'lambda': lambda_restricted,
                 'F_wald': F_wald,
-                'p_wald': 1-stats.f.cdf(x=F_wald, dfn=1, dfd=n-c-1),
+                'p_wald': stats.f.sf(x=F_wald, dfn=1, dfd=n-c-1),
             })
         except np.linalg.LinAlgError as e:
             print(e)


### PR DESCRIPTION
1-cdf for the Wald test capped p-values at 1e-16 before rounded to 0. Now, we use `scipy.stats.sf(x, dfn, dfd, loc=0, scale=1)` instead, which provides enough precision.